### PR TITLE
File Entry Padding Correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3] - 2019-11-20
+
+### Fixed
+
+- File entries are correctly padded to the 512 byte boundary without introducing
+  entire 512 byte blocks of null data.
+
+## [0.1.2] - 2019-09-06
+
+## [0.1.1] - 2019-08-27
+
+## [0.1.0] - 2015-02-23
+
+## [0.0.1] - 2015-02-18
+
+[Unreleased]: https://github.com/conjurinc/memtar/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/conjurinc/memtar/compare/v0.1.1...v0.1.3
+[0.1.2]: https://github.com/conjurinc/memtar/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/conjurinc/memtar/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/conjurinc/memtar/compare/v0.0.1...v0.1.0
+[0.0.1]: https://github.com/conjurinc/memtar/compare/v0.0.1

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,15 @@
+FROM ruby:2.5
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY memtar.gemspec /src
+COPY Gemfile /src
+COPY Gemfile.lock /src
+COPY lib/memtar/version.rb /src/lib/memtar/
+
+RUN bundle install
+
+COPY . /src/
+
+CMD [ "rake", "spec" ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+PATH
+  remote: .
+  specs:
+    memtar (0.1.3)
+      minitar (~> 0.8)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    minitar (0.9)
+    rake (10.5.0)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.0)
+      rspec-support (~> 3.9.0)
+    rspec-expectations (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.7)
+  memtar!
+  rake (~> 10.0)
+  rspec (~> 3.2)
+
+BUNDLED WITH
+   1.17.2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,26 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent { label 'executor-v2' }
+
+  options {
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+
+  triggers {
+    cron(getDailyCronString())
+  }
+
+  stages {
+    stage('Test') {
+      steps { sh './test.sh' }
+    }
+  }
+
+  post {
+    always {
+      cleanupAndNotify(currentBuild.currentResult)
+    }
+  }
+}

--- a/lib/memtar.rb
+++ b/lib/memtar.rb
@@ -16,7 +16,7 @@ class MemTar
     size = content.bytesize
     @io.write header opts.merge size: size, name: path
     @io.write content
-    @io.write "\0" * (512 - size % 512)
+    @io.write "\0" * ((512 - size % 512) % 512)
   end
 
   def add_symlink path, target

--- a/lib/memtar/version.rb
+++ b/lib/memtar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class MemTar
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/memtar.gemspec
+++ b/memtar.gemspec
@@ -6,8 +6,8 @@ require 'memtar/version'
 Gem::Specification.new do |spec|
   spec.name          = "memtar"
   spec.version       = MemTar::VERSION
-  spec.authors       = ["Rafał Rzepecki"]
-  spec.email         = ["rafal@conjur.net"]
+  spec.authors       = ["CyberArk", "Rafał Rzepecki", "Micah Lee"]
+  spec.email         = ["conj_maintainers@cyberark.com"]
   spec.summary       = %q{In-memory tar archive creation}
   spec.homepage      = "https://github.com/conjurinc/memtar"
   spec.license       = "MIT"

--- a/spec/memtar_spec.rb
+++ b/spec/memtar_spec.rb
@@ -25,7 +25,7 @@ describe MemTar do
       file.close
 
       subject.add_file 'xyzzy', File.new(file.path)
-      has_file 'xyzzy', content: 'bar', mode: 0750, uname: Etc.getlogin
+      has_file 'xyzzy', content: 'bar', mode: 0750, uname: Etc.getpwuid.name
       file.unlink
     end
 

--- a/spec/memtar_spec.rb
+++ b/spec/memtar_spec.rb
@@ -29,6 +29,13 @@ describe MemTar do
       file.unlink
     end
 
+    it 'handles content that is a factor of 512 bytes' do
+      subject.add_file 'test_file', 'a' * 512
+      subject.add_file 'another_test_file', 'some content'
+
+      has_file 'another_test_file', content: 'some content'
+    end
+
     it 'handles symlinks as File arguments' do
       file = Tempfile.new 'foo'
       path = file.path

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+
+docker build -f Dockerfile.test -t memtar_test .
+docker run --rm -v "$(pwd):/src" memtar_test rake spec


### PR DESCRIPTION
Closes #2 

This PR updates the file entry padding calculation to account for files that are exact factors of 512 bytes. The current calculation, `512 - (size % 512)`, adds an entire 512 block of null bytes for this case, resulting in an invalid tar archive.

It accomplishes this by adding a final modulus operation (`% 512`) to ensure an even division results in a `0` result.