### PR TITLE
WIP: Upgrade bundler to resolve CVE-2019-3881

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -8,6 +8,7 @@ COPY Gemfile /src
 COPY Gemfile.lock /src
 COPY lib/memtar/version.rb /src/lib/memtar/
 
+RUN gem install bundler -v 2.1.4
 RUN bundle install
 
 COPY . /src/

--- a/memtar.gemspec
+++ b/memtar.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "minitar", "~> 0.8"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.1.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
 end


### PR DESCRIPTION
Upgrade Bundler to 2.1.0 to resolve CVE-2019-3881.

Currently, Bundler stays pegged at 1.17.2 even with the updates. 🤷🏻‍♂️ 


Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>