### PR TITLE
Upgrade Bundler to resolve CVE-2020-36327

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,7 @@
 FROM ruby:2.5
 
+ENV BUNDLER_VERSION 2.2.18
+
 RUN mkdir /src
 WORKDIR /src
 
@@ -8,7 +10,7 @@ COPY Gemfile /src
 COPY Gemfile.lock /src
 COPY lib/memtar/version.rb /src/lib/memtar/
 
-RUN bundle install
+RUN gem install bundler:$BUNDLER_VERSION && bundle install
 
 COPY . /src/
 

--- a/memtar.gemspec
+++ b/memtar.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "minitar", "~> 0.8"
 
-  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "bundler", "~> 2.2.18"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.2"
 end


### PR DESCRIPTION
Updates Bundler to 2.2.18 to resolve CVE-2020-36327

Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>