### PR TITLE
Switch test image to slim base image and unpin to major version

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,15 @@
-FROM ruby:3.0.4
+FROM ruby:3-slim
 
 ENV BUNDLER_VERSION 2.2.18
+
+
+RUN apt-get update && \
+    # Pull latest OS package updates to reduce risk of vulnerable
+    # packages.
+    apt-get dist-upgrade -y && \
+    # git is required to install some of the ruby gem dependencies
+    apt-get install -y git && \
+    apt-get clean
 
 RUN mkdir /src
 WORKDIR /src


### PR DESCRIPTION

### Desired Outcome

This PR updates the test Docker image to use a slim base image and a less restrictive version pinning to allow it to track with updates more rapidly.

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [x] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
